### PR TITLE
Crudder transactions

### DIFF
--- a/_glue/classes/glue/CRUDder/CRUDder.php
+++ b/_glue/classes/glue/CRUDder/CRUDder.php
@@ -194,19 +194,10 @@ abstract class CRUDder implements CRUDderI
         $statement->execute($values);
     }
     //transactions
-    public static function beginTransaction()
+    public static function getTransacter()
     {
         $class = get_called_class();
-        return $class::$conn->beginTransaction();
-    }
-    public static function commit()
-    {
-        //TODO: implement commit
-    }
-    public static function rollback()
-    {
-        $class = get_called_class();
-        return $class::$conn->rollback();
+        return new Transacter($class::$conn);
     }
     //getting and setting
     public function __get($key)

--- a/_glue/classes/glue/CRUDder/CRUDder.php
+++ b/_glue/classes/glue/CRUDder/CRUDder.php
@@ -194,17 +194,19 @@ abstract class CRUDder implements CRUDderI
         $statement->execute($values);
     }
     //transactions
-    public static function transactionStart()
+    public static function beginTransaction()
     {
-        die('TODO: implement transactionStart');
+        $class = get_called_class();
+        return $class::$conn->beginTransaction();
     }
-    public static function transactionCommit()
+    public static function commit()
     {
-        die('TODO: implement transactionCommit');
+        //TODO: implement commit
     }
-    public static function transactionDiscard()
+    public static function rollback()
     {
-        die('TODO: implement transactionDiscard');
+        $class = get_called_class();
+        return $class::$conn->rollback();
     }
     //getting and setting
     public function __get($key)

--- a/_glue/classes/glue/CRUDder/CRUDderI.php
+++ b/_glue/classes/glue/CRUDder/CRUDderI.php
@@ -31,9 +31,9 @@ interface CRUDderI
     public function update();
     public function delete();
     // transactions
-    public static function transactionStart();
-    public static function transactionCommit();
-    public static function transactionDiscard();
+    public static function beginTransaction();
+    public static function commit();
+    public static function rollback();
     // get/set
     public function __get($key);
     public function __set($key, $val);

--- a/_glue/classes/glue/CRUDder/CRUDderI.php
+++ b/_glue/classes/glue/CRUDder/CRUDderI.php
@@ -31,9 +31,7 @@ interface CRUDderI
     public function update();
     public function delete();
     // transactions
-    public static function beginTransaction();
-    public static function commit();
-    public static function rollback();
+    public static function getTransacter();
     // get/set
     public function __get($key);
     public function __set($key, $val);

--- a/_glue/classes/glue/CRUDder/Transacter.php
+++ b/_glue/classes/glue/CRUDder/Transacter.php
@@ -1,0 +1,54 @@
+<?php
+ /**
+  * Glue Framework
+  * Copyright (C) 2015 Joby Elliott
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation; either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License along
+  * with this program; if not, write to the Free Software Foundation, Inc.,
+  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+namespace glue\CRUDder;
+
+class Transacter
+{
+    protected $transactionID;
+    protected static $conn;
+    protected static $transactions = array();
+
+    public function __construct($conn)
+    {
+        $this->transactionID = rand();
+        static::$conn = $conn;
+    }
+    public function beginTransaction()
+    {
+        static::$transactions[] = $this->transactionID;
+        return static::$conn->exec('SAVEPOINT trans' . count(static::$transactions)) >= 1;
+    }
+    public function rollback()
+    {
+        if (end(static::$transactions) != $this->transactionID) {
+            return false;
+        }
+        array_pop(static::$transactions);
+        return static::$conn->exec('ROLLBACK TO trans' . (count(static::$transactions)+1)) >= 1;
+    }
+    public function commit()
+    {
+        if (end(static::$transactions) != $this->transactionID) {
+            return false;
+        }
+        array_pop(static::$transactions);
+        return count(static::$transactions) == 0;
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
   <testsuites>
     <testsuite name="CRUDder">
       <file>tests/glue/CRUDder/CRUDderTest.php</file>
+      <file>tests/glue/CRUDder/CRUDderTransactionsTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/glue/CRUDder/CRUDderTest.php
+++ b/tests/glue/CRUDder/CRUDderTest.php
@@ -17,11 +17,13 @@
   * with this program; if not, write to the Free Software Foundation, Inc.,
   * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+namespace glue\CRUDder\CoreTest;
+
 use \glue\CRUDder\CRUDder;
 use \glue\CRUDder\CRUDderFormatter;
 use \glue\CRUDder\DB;
 
-class CRUDderTest extends PHPUnit_Extensions_Database_TestCase
+class CRUDderTest extends \PHPUnit_Extensions_Database_TestCase
 {
     public static $conn = null;
     protected static $createArray1 = array(
@@ -134,7 +136,7 @@ class CRUDderTest extends PHPUnit_Extensions_Database_TestCase
     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
     */
     public function getDataSet() {
-        return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+        return new \PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 }
 

--- a/tests/glue/CRUDder/CRUDderTransactionsTest.php
+++ b/tests/glue/CRUDder/CRUDderTransactionsTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+  * Glue Framework
+  * Copyright (C) 2015 Joby Elliott
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation; either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License along
+  * with this program; if not, write to the Free Software Foundation, Inc.,
+  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+namespace glue\CRUDder\TransactionsTest;
+
+use \glue\CRUDder\CRUDder;
+use \glue\CRUDder\CRUDderFormatter;
+use \glue\CRUDder\DB;
+
+class CRUDderTransactionsTest extends \PHPUnit_Extensions_Database_TestCase
+{
+    public static $conn = null;
+    protected static $createArray1 = array(
+        'string' => 'Created Object 1'
+    );
+    protected static $createArray2 = array(
+        'string' => 'Created Object 2'
+    );
+
+    public function testTransactions()
+    {
+        $this->assertTrue(BasicObject::beginTransaction());
+        //add an object and rollback
+        $f1 = BasicObject::create(static::$createArray1);
+        BasicObject::rollback();
+        //there should be no ID 1
+        $this->assertFalse(BasicObject::read(1),'rollback() didn\'t prevent changes from saving');
+        //add an object and commit
+        $f1 = BasicObject::create(static::$createArray1);
+        $this->assertTrue(BasicObject::commit());//no way to test commit
+    }
+
+    /**
+    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+    */
+    public function getConnection() {
+        $pdo = DB::getConnection('sqlite::memory:', null, null);
+        //basicObject schema
+        $pdo->exec('DROP TABLE IF EXISTS BasicObject');
+        $pdo->exec('CREATE TABLE BasicObject (
+            bo_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            bo_string VARCHAR(30) NOT NULL)');
+        static::$conn = &$pdo;
+        //return
+        return $this->createDefaultDBConnection(static::$conn);
+    }
+    /**
+    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+    */
+    public function getDataSet() {
+        return new \PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
+}
+
+Class TestCRUDder extends CRUDder {}
+TestCRUDder::configureDB('sqlite::memory:', null, null);
+
+class BasicObject extends TestCRUDder
+{
+    protected static $cTable = 'BasicObject';
+    protected static $cKey = 'id';
+    protected static $cSort = '@@id@@ DESC';
+    protected static $cFields = array(
+        'id' => array(
+            'col' => 'bo_id',
+            'type' => 'int'
+        ),
+        'string' => array(
+            'col' => 'bo_string',
+            'type' => 'string'
+        )
+    );
+}
+BasicObject::configureClass(file_get_contents(__DIR__ . '/BasicObject.yaml'));


### PR DESCRIPTION
CRUDder now supports transactions, via CRUDder::getTransacter(), which will yield a Transacter object, which contains the fairly self-explanatory methods beginTransaction(), commit() and rollback()
